### PR TITLE
Adjust cycle pacing and animation playback limits

### DIFF
--- a/index.html
+++ b/index.html
@@ -1501,12 +1501,13 @@
         function startSimulation() {
             if (state.paused) return;
             clearIntervals();
-            const baseGameSpeed = 4500;
+            const baseGameSpeed = 6000;
             const baseAnimSpeed = 1200;
             const baseActionSpeed = 6000;
 
             gameInterval = setInterval(update, baseGameSpeed / state.speed);
-            animInterval = setInterval(animate, baseAnimSpeed / state.speed);
+            const animationSpeedMultiplier = Math.min(Math.max(state.speed, 1), 2);
+            animInterval = setInterval(animate, baseAnimSpeed / animationSpeedMultiplier);
             actionInterval = setInterval(autoAction, baseActionSpeed / state.speed);
             moodInterval = setInterval(updateMood, 12000 / state.speed);
             eventCheckInterval = setInterval(checkRareEvents, 22500 / state.speed);


### PR DESCRIPTION
## Summary
- slow the base simulation cycle timing to stretch each age increment
- clamp animation interval changes between 1x and 2x so slowing cycles no longer slows the art while keeping a reasonable upper limit

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1cb68eeb08322b52fb2806d8628ea