### PR TITLE
Enforce minimum cycles per stage before transformation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1330,6 +1330,7 @@
             harmony: 75,
             age: 0,
             stage: 0,
+            stageCycleCount: 0,
             animFrame: 0,
             paused: false,
             pauseReason: null,
@@ -1352,6 +1353,7 @@
             nextLocationDelay: 0
         };
 
+        const MIN_STAGE_DURATION = 10;
         const LOG_MAX_ENTRIES = 60;
         const logEntries = [];
 
@@ -1620,6 +1622,7 @@
             state.flux = 50 + bonusFlux;
             state.harmony = 80;
             state.age = 0;
+            state.stageCycleCount = 0;
             state.animFrame = 0;
             state.location = 'white_forest';
             state.visitedLocations.add('white_forest');
@@ -1710,6 +1713,10 @@
         }
 
         function updateStage() {
+            if (state.stageCycleCount < MIN_STAGE_DURATION) {
+                return;
+            }
+
             let newStage = state.stage;
             for (let i = stages.length - 1; i > state.stage; i--) {
                 if (state.saturation >= stages[i].threshold) {
@@ -1725,6 +1732,7 @@
 
             state.stage = newStage;
             state.animFrame = 0;
+            state.stageCycleCount = 0;
 
             let stageMessage;
             if (newStage >= 13) {
@@ -1920,6 +1928,7 @@
             if (state.paused) return;
             state.age++;
             state.totalAge++;
+            state.stageCycleCount++;
             state.flux = Math.max(0, state.flux - 2);
             state.harmony = Math.max(0, state.harmony - 1);
 


### PR DESCRIPTION
## Summary
- track how many cycles the creature spends in its current stage
- require at least ten cycles before allowing another stage transformation
- reset the stage cycle counter during rebirths and after each stage shift

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1d9ed56a08322b7ec59286c4a7a61