### PR TITLE
Reposition creature metrics below event text

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@
             border: 2px solid #d0d0c8;
             border-radius: 10px;
             padding: 20px;
+            padding-bottom: 90px;
             min-height: 200px;
             margin-bottom: 20px;
             text-align: center;
@@ -185,12 +186,13 @@
         }
         .creature-metrics {
             position: absolute;
-            top: 14px;
+            left: 14px;
             right: 14px;
-            display: grid;
-            gap: 6px;
-            max-width: 45%;
-            justify-items: end;
+            bottom: 14px;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 8px;
             pointer-events: none;
         }
         .creature-metric {
@@ -694,13 +696,14 @@
             }
             .display {
                 padding: 14px;
+                padding-bottom: 88px;
                 min-height: 160px;
             }
             .creature-metrics {
-                top: 12px;
+                left: 12px;
                 right: 12px;
-                max-width: 70%;
-                gap: 5px;
+                bottom: 12px;
+                gap: 6px;
             }
             .creature-metric {
                 font-size: 0.65em;


### PR DESCRIPTION
## Summary
- move the creature metric badges to the bottom of the display so they no longer overlap the stage title
- increase the display's bottom padding so the metrics sit comfortably beneath the event text
- update responsive spacing so the metrics remain aligned on small screens

## Testing
- Visual inspection in browser

------
https://chatgpt.com/codex/tasks/task_e_68e1e6215ecc8322a1a527e758ce5ea3