### PR TITLE
Shrink creature metric overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,23 +190,23 @@
             right: 14px;
             bottom: 14px;
             display: flex;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             justify-content: center;
-            gap: 8px;
+            gap: 6px;
             pointer-events: none;
         }
         .creature-metric {
             background: rgba(255, 255, 255, 0.9);
             border: 1px solid #d0d0c8;
             border-radius: 999px;
-            padding: 6px 12px;
-            font-size: 0.7em;
-            letter-spacing: 0.5px;
+            padding: 4px 10px;
+            font-size: 0.62em;
+            letter-spacing: 0.4px;
             color: #6a6a60;
             text-transform: uppercase;
             display: flex;
             align-items: center;
-            gap: 6px;
+            gap: 4px;
             box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
             backdrop-filter: blur(2px);
             pointer-events: auto;


### PR DESCRIPTION
## Summary
- reduce padding and font size of creature metric overlays so they fit beneath the creature display
- prevent the overlay row from wrapping to keep all metrics on a single line

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1e6f5af90832283c7f00e9dc3d154