### PR TITLE
Stack creature metrics in two rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,10 +318,12 @@
             left: 14px;
             right: 14px;
             bottom: 14px;
-            display: flex;
-            flex-wrap: nowrap;
+            display: grid;
+            grid-template-columns: repeat(2, auto);
             justify-content: center;
-            gap: 6px;
+            align-content: center;
+            column-gap: 8px;
+            row-gap: 6px;
             pointer-events: none;
         }
         .creature-metric {


### PR DESCRIPTION
## Summary
- arrange the creature status overlays in a centered two-by-two grid to keep longer labels within the panel

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1e973f8d083228f4c0fce249f5169