### PR TITLE
Improve desktop panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,35 +20,37 @@
         }
         .panel-slider {
             display: grid;
-            gap: 20px;
+            gap: 24px;
             max-width: 1200px;
             width: 100%;
-            grid-template-columns: minmax(0, 1fr) 320px;
+            margin: 0 auto;
+            grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
             align-items: start;
         }
         .panel {
             display: flex;
             align-items: stretch;
-        }
-        .panel.creature-panel {
-            grid-column: 1;
-            justify-content: flex-start;
-        }
-        .panel.map-panel {
-            grid-column: 1;
-            justify-content: flex-start;
-        }
-        .panel.locations-panel {
-            grid-column: 2;
-            justify-content: flex-start;
-        }
-        .panel.inventory-panel {
-            grid-column: 2;
-            justify-content: flex-start;
+            justify-content: center;
+            width: 100%;
         }
         .panel.log-panel {
             grid-column: 1 / -1;
-            justify-content: center;
+        }
+        @media (min-width: 961px) {
+            .panel-slider {
+                grid-template-columns: repeat(12, minmax(0, 1fr));
+                grid-auto-flow: row dense;
+            }
+            .panel.creature-panel {
+                grid-column: span 7;
+            }
+            .panel.map-panel {
+                grid-column: span 5;
+            }
+            .panel.locations-panel,
+            .panel.inventory-panel {
+                grid-column: span 6;
+            }
         }
         .container {
             background: white;


### PR DESCRIPTION
## Summary
- update the desktop panel grid to use a responsive column layout that keeps sections aligned and centered
- preserve the existing mobile slider configuration while refining wide-screen column spans for each panel

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1eaf7f76c8322ace0ec04b73eb8fe